### PR TITLE
minor changes. cannot assume hostname unchanged

### DIFF
--- a/src/php/ext/grpc/channel.c
+++ b/src/php/ext/grpc/channel.c
@@ -86,7 +86,8 @@ zend_object_value create_wrapped_grpc_channel(zend_class_entry *class_type
   return retval;
 }
 
-void php_grpc_read_args_array(zval *args_array, grpc_channel_args *args TSRMLS_DC) {
+void php_grpc_read_args_array(zval *args_array,
+                              grpc_channel_args *args TSRMLS_DC) {
   HashTable *array_hash;
   HashPosition array_pointer;
   int args_index;

--- a/src/php/ext/grpc/channel_credentials.c
+++ b/src/php/ext/grpc/channel_credentials.c
@@ -96,7 +96,8 @@ zend_object_value create_wrapped_grpc_channel_credentials(
   return retval;
 }
 
-zval *grpc_php_wrap_channel_credentials(grpc_channel_credentials *wrapped TSRMLS_DC) {
+zval *grpc_php_wrap_channel_credentials(grpc_channel_credentials
+                                        *wrapped TSRMLS_DC) {
   zval *credentials_object;
   MAKE_STD_ZVAL(credentials_object);
   object_init_ex(credentials_object, grpc_ce_channel_credentials);

--- a/src/php/ext/grpc/server_credentials.c
+++ b/src/php/ext/grpc/server_credentials.c
@@ -84,7 +84,8 @@ zend_object_value create_wrapped_grpc_server_credentials(
   return retval;
 }
 
-zval *grpc_php_wrap_server_credentials(grpc_server_credentials *wrapped TSRMLS_DC) {
+zval *grpc_php_wrap_server_credentials(grpc_server_credentials
+                                       *wrapped TSRMLS_DC) {
   zval *server_credentials_object;
   MAKE_STD_ZVAL(server_credentials_object);
   object_init_ex(server_credentials_object, grpc_ce_server_credentials);

--- a/src/php/ext/grpc/timeval.c
+++ b/src/php/ext/grpc/timeval.c
@@ -166,7 +166,8 @@ PHP_METHOD(Timeval, add) {
   wrapped_grpc_timeval *other =
       (wrapped_grpc_timeval *)zend_object_store_get_object(other_obj TSRMLS_CC);
   zval *sum =
-      grpc_php_wrap_timeval(gpr_time_add(self->wrapped, other->wrapped) TSRMLS_CC);
+      grpc_php_wrap_timeval(gpr_time_add(self->wrapped, other->wrapped)
+                            TSRMLS_CC);
   RETURN_DESTROY_ZVAL(sum);
 #else
   wrapped_grpc_timeval *self = Z_WRAPPED_GRPC_TIMEVAL_P(getThis());
@@ -200,7 +201,8 @@ PHP_METHOD(Timeval, subtract) {
   wrapped_grpc_timeval *other =
       (wrapped_grpc_timeval *)zend_object_store_get_object(other_obj TSRMLS_CC);
   zval *diff =
-      grpc_php_wrap_timeval(gpr_time_sub(self->wrapped, other->wrapped) TSRMLS_CC);
+      grpc_php_wrap_timeval(gpr_time_sub(self->wrapped, other->wrapped)
+                            TSRMLS_CC);
   RETURN_DESTROY_ZVAL(diff);
 #else
   wrapped_grpc_timeval *self = Z_WRAPPED_GRPC_TIMEVAL_P(getThis());

--- a/src/php/tests/unit_tests/CallCredentialsTest.php
+++ b/src/php/tests/unit_tests/CallCredentialsTest.php
@@ -148,7 +148,8 @@ class CallCredentialsTest extends PHPUnit_Framework_TestCase
             $this->call_credentials,
             $call_credentials2
         );
-        $this->assertSame('Grpc\CallCredentials', get_class($call_credentials3));
+        $this->assertSame('Grpc\CallCredentials',
+                          get_class($call_credentials3));
     }
 
     /**

--- a/src/php/tests/unit_tests/CallTest.php
+++ b/src/php/tests/unit_tests/CallTest.php
@@ -101,7 +101,6 @@ class CallTest extends PHPUnit_Framework_TestCase
 
     public function testGetPeer()
     {
-        $this->assertStringStartsWith('localhost:', $this->call->getPeer());
         $this->assertTrue(is_string($this->call->getPeer()));
     }
 

--- a/src/php/tests/unit_tests/CallTest.php
+++ b/src/php/tests/unit_tests/CallTest.php
@@ -93,7 +93,8 @@ class CallTest extends PHPUnit_Framework_TestCase
     {
         $batch = [
             Grpc\OP_SEND_INITIAL_METADATA => ['key1' => ['value1'],
-                                              'key2' => ['value2', 'value3'], ],
+                                              'key2' => ['value2',
+                                                         'value3'], ],
         ];
         $result = $this->call->startBatch($batch);
         $this->assertTrue($result->send_metadata);

--- a/src/php/tests/unit_tests/ChannelCredentialsTest.php
+++ b/src/php/tests/unit_tests/ChannelCredentialsTest.php
@@ -44,7 +44,8 @@ class ChanellCredentialsTest extends PHPUnit_Framework_TestCase
 
     public function testCreateSslWith3Null()
     {
-        $channel_credentials = Grpc\ChannelCredentials::createSsl(null, null, null);
+        $channel_credentials = Grpc\ChannelCredentials::createSsl(null, null,
+                                                                  null);
         $this->assertNotNull($channel_credentials);
     }
 

--- a/src/php/tests/unit_tests/ChannelTest.php
+++ b/src/php/tests/unit_tests/ChannelTest.php
@@ -91,7 +91,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         $this->channel = new Grpc\Channel('localhost:8888',
              ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $target = $this->channel->getTarget();
-        $this->assertSame('localhost:8888', $target);
+        $this->assertTrue(is_string($target));
     }
 
     public function testWatchConnectivityState()

--- a/src/php/tests/unit_tests/EndToEndTest.php
+++ b/src/php/tests/unit_tests/EndToEndTest.php
@@ -521,7 +521,8 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
 
     public function testGetConnectivityState()
     {
-        $this->assertTrue($this->channel->getConnectivityState() == Grpc\CHANNEL_IDLE);
+        $this->assertTrue($this->channel->getConnectivityState() ==
+                          Grpc\CHANNEL_IDLE);
     }
 
     public function testWatchConnectivityStateFailed()

--- a/src/php/tests/unit_tests/ServerTest.php
+++ b/src/php/tests/unit_tests/ServerTest.php
@@ -76,7 +76,8 @@ class ServerTest extends PHPUnit_Framework_TestCase
         $call = new Grpc\Call($channel, 'dummy_method', $deadline);
 
         $event = $call->startBatch([Grpc\OP_SEND_INITIAL_METADATA => [],
-                                     Grpc\OP_SEND_CLOSE_FROM_CLIENT => true, ]);
+                                    Grpc\OP_SEND_CLOSE_FROM_CLIENT => true,
+                                    ]);
 
         $c = $this->server->requestCall();
         $this->assertObjectHasAttribute('call', $c);

--- a/src/php/tests/unit_tests/ServerTest.php
+++ b/src/php/tests/unit_tests/ServerTest.php
@@ -83,7 +83,7 @@ class ServerTest extends PHPUnit_Framework_TestCase
         $this->assertObjectHasAttribute('method', $c);
         $this->assertSame('dummy_method', $c->method);
         $this->assertObjectHasAttribute('host', $c);
-        $this->assertSame('localhost:8888', $c->host);
+        $this->assertTrue(is_string($c->host));
         $this->assertObjectHasAttribute('absolute_deadline', $c);
         $this->assertObjectHasAttribute('metadata', $c);
 
@@ -100,55 +100,7 @@ class ServerTest extends PHPUnit_Framework_TestCase
 
         return $server_credentials;
     }
-/*
-    //TODO(thinkerou): make cases of addHttp2Port right
-    public function testAddHttp2Port()
-    {
-        $this->server = new Grpc\Server();
-        $port = $this->server->addHttp2Port('127.0.0.1:8080');
-        $this->assertEquals(8080, $port);
-    }
 
-    public function testAddHttp2Port1()
-    {
-        $this->server = new Grpc\Server([]);
-        $port = $this->server->addHttp2Port('127.0.0.1:8080');
-        $this->assertEquals(8080, $port);
-    }
-
-    public function testAddHttp2Port2()
-    {
-        $this->server = new Grpc\Server(['ip' => '127.0.0.1',
-                                          'port' => '8888', ]);
-        $port = $this->server->addHttp2Port('127.0.0.1:8080');
-        $this->assertEquals(8080, $port);
-    }
-
-    public function testAddSecureHttp2Port()
-    {
-        $this->server = new Grpc\Server();
-        $cred = $this->createSslObj();
-        $port = $this->server->addSecureHttp2Port('127.0.0.1:8080', $cred);
-        $this->assertEquals(8080, $port);
-    }
-
-    public function testAddSecureHttp2Port1()
-    {
-        $this->server = new Grpc\Server([]);
-        $cred = $this->createSslObj();
-        $port = $this->server->addSecureHttp2Port('127.0.0.1:8080', $cred);
-        $this->assertEquals(8080, $port);
-    }
-
-    public function testAddSecureHttp2Port2()
-    {
-        $this->server = new Grpc\Server(['ip' => '127.0.0.1',
-                                         'port' => '8888', ]);
-        $cred = $this->createSslObj();
-        $port = $this->server->addSecureHttp2Port('127.0.0.1:8080', $cred);
-        $this->assertEquals(8080, $port);
-    }
-*/
     /**
      * @expectedException InvalidArgumentException
      */
@@ -158,16 +110,6 @@ class ServerTest extends PHPUnit_Framework_TestCase
         $this->assertNull($this->server);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
-/*    public function testInvalidConstructor2()
-    {
-        //TODO(thinkerou): it crash when key is long on php7
-        $this->server = new Grpc\server(['0.0.0.0:0']);
-        $this->assertNull($this->server);
-    }
-*/
     /**
      * @expectedException InvalidArgumentException
      */


### PR DESCRIPTION
Just minor changes. I don't think we can assume the hostname or target we get back from the C Core library is what we put in, because of various reasons, like load balancing, etc. It just so happened like `localhost:8888` is being returned now but it's not guaranteed. 

Also removed some commented out code. I'd prefer we not check in commented out code. We can always add them later.
